### PR TITLE
Add iterable to list messages in reverse order.

### DIFF
--- a/gitterpy/gitterpy.py
+++ b/gitterpy/gitterpy.py
@@ -94,14 +94,18 @@ class Gitter(object):
     API self-throttling: Between every iteration, the generator sleeps the
     process for some float value ``sleep_time`` in seconds.
     """
-    room_id = self.roomIdFromName(room_name)
 
+    def iter_check(d):
+      if not d:
+        raise StopIteration()
+      return d[0].get("id")
+
+    room_id = self.roomIdFromName(room_name)
+    
     # yield first batch of <= 100 message objects
     url_f = "rooms/{0}/chatMessages?limit=100"
     data = self._get(url_f.format(room_id))
-    if not data:
-      raise StopIteration()
-    before_id = data[0].get("id")
+    before_id = iter_check(data)
     for message in reversed(data):
       yield message
 
@@ -109,11 +113,8 @@ class Gitter(object):
     url_f = "rooms/{0}/chatMessages?limit=100&beforeId={1}"
     while True:
       sleep(sleep_time)
-
       data = self._get(url_f.format(room_id, before_id))
-      if not data:
-        raise StopIteration()
-      before_id = data[0].get("id")
+      before_id = iter_check(data)
       for message in reversed(data):
         yield message
 

--- a/gitterpy/gitterpy.py
+++ b/gitterpy/gitterpy.py
@@ -6,6 +6,7 @@
 """
 
 import requests, urlparse, json
+from time import sleep
 
 class Gitter(object):
   rest_api_url = "https://api.gitter.im/v1/"
@@ -83,6 +84,40 @@ class Gitter(object):
       if room.get("name") == room_name:
         return room.get("id")
     return None
+
+  def listMessagesCursor(self, room_name, sleep_time=1.0):
+    """
+    Makes a cursor to iterate through message objects present to past.
+
+    See: https://developer.gitter.im/docs/messages-resource
+
+    API self-throttling: Between every iteration, the generator sleeps the
+    process for some float value ``sleep_time`` in seconds.
+    """
+    room_id = self.roomIdFromName(room_name)
+
+    # yield first batch of <= 100 message objects
+    url_f = "rooms/{0}/chatMessages?limit=100"
+    data = self._get(url_f.format(room_id))
+    if not data:
+      raise StopIteration()
+    before_id = data[0].get("id")
+    for message in reversed(data):
+      yield message
+
+    # yield consecutive batches
+    url_f = "rooms/{0}/chatMessages?limit=100&beforeId={1}"
+    while True:
+      sleep(sleep_time)
+
+      data = self._get(url_f.format(room_id, before_id))
+      if not data:
+        raise StopIteration()
+      before_id = data[0].get("id")
+      for message in reversed(data):
+        yield message
+
+    StopIteration()
 
   def _stream(self, path):
     """ Makes a GET request to the given path, returning the response

--- a/gitterpy/gitterpy.py
+++ b/gitterpy/gitterpy.py
@@ -117,7 +117,7 @@ class Gitter(object):
       for message in reversed(data):
         yield message
 
-    StopIteration()
+    raise StopIteration()
 
   def _stream(self, path):
     """ Makes a GET request to the given path, returning the response


### PR DESCRIPTION
Added a new API wrapper instance method for the List Messages command.

gitter.Gitter.listMessagesCursor: Makes a request for 100 (or less) message objects repeatedly, and yields each individual message object in reverse order (ie. newer message objects are first to be iterated over). Iterates until there is chat history to be consumed from the room.